### PR TITLE
Added Code snipped to load IANA tld file instead of predefined tld

### DIFF
--- a/ext_scripts/update_tlds.php
+++ b/ext_scripts/update_tlds.php
@@ -1,0 +1,11 @@
+<?php
+$allTlds = explode("\n",file_get_contents("http://data.iana.org/TLD/tlds-alpha-by-domain.txt"));
+
+$DbInsertQuery = "";
+foreach ($allTlds as $key => $value) {
+    if (strpos($value, "#") === false && strlen(trim($value)) > 0) $DbInsertQuery .= "('" . $value . "')," ;
+}
+$DbInsertQuery = rtrim($DbInsertQuery, ",");
+$db->qry("delete from %prefix%%plain%", "tlds");
+$db->qry("INSERT INTO %prefix%%plain% (tld) VALUES %plain%", "tlds", $DbInsertQuery);
+?>

--- a/inc/classes/class_masterform.php
+++ b/inc/classes/class_masterform.php
@@ -699,36 +699,20 @@ class masterform {
 
 // Error-Callback-Functions
 function CheckValidEmail($email){
-global $cfg;
+global $cfg, $db;
 
   if ($email == '') return t('Bitte gib deine Email ein');
   elseif (substr_count($email, '@') != 1) return t('Die Adresse muss genau ein @-Zeichen enthalten');
   else {	
-    $allTLD = array();
-    // can be loaded via  'wget -O tlds.txt http://data.iana.org/TLD/tlds-alpha-by-domain.txt'
-    // try to open tlds.txt in root folder which should contain all allowed tlds (http://data.iana.org/TLD/tlds-alpha-by-domain.txt)
-    if (file_exists ("tlds.txt")) {
-            $tldFile = fopen("tlds.txt","r");
-            while(!feof($tldFile)){
-                    $line = fgets($tldFile);
-                    $allTLD[] = strtolower(trim($line));
-            }
-            fclose($tldFile);
-    } else {
-        $ccTLD = array('ac', 'ad', 'ae', 'af', 'ag', 'ai', 'al', 'am', 'an', 'ao', 'aq', 'ar', 'as', 'at', 'au', 'aw', 'az', 'ba', 'bb', 'bd', 'be', 'bf', 'bg', 'bh', 'bi', 'bj', 'bm', 'bn', 'bo', 'br', 'bs', 'bt', 'bv', 'bw', 'by', 'bz', 'ca', 'cc', 'cd', 'cf', 'cg', 'ch', 'ci', 'ck', 'cl', 'cm', 'cn', 'co', 'cr', 'cu', 'cv', 'cx', 'cy', 'cz', 'de', 'dj', 'dk', 'dm', 'do', 'dz', 'ec', 'ee', 'eg', 'eh', 'er', 'es', 'et', 'fi', 'fj', 'fk', 'fm', 'fo', 'fr', 'ga', 'gd', 'ge', 'gf', 'gg', 'gh', 'gi', 'gl', 'gm', 'gn', 'gp', 'gq', 'gr', 'gs', 'gt', 'gu', 'gw', 'gy', 'hk', 'hm', 'hn', 'hr', 'ht', 'hu', 'id', 'ie', 'il', 'im', 'in', 'io', 'iq', 'ir', 'is', 'it', 'je', 'jm', 'jo', 'jp', 'ke', 'kg', 'kh', 'ki', 'km', 'kn', 'kp', 'kr', 'kw', 'ky', 'kz', 'la', 'lb', 'lc', 'li', 'lk', 'lr', 'ls', 'lt', 'lu', 'lv', 'ly', 'ma', 'mc', 'md', 'mg', 'mh', 'mk', 'ml', 'mm', 'mn', 'mo', 'mp', 'mq', 'mr', 'ms', 'mt', 'mu', 'mv', 'mw', 'mx', 'my', 'mz', 'na', 'nc', 'ne', 'nf', 'ng', 'ni', 'nl', 'no', 'np', 'nr', 'nu', 'nz', 'om', 'pa', 'pe', 'pf', 'pg', 'ph', 'pk', 'pl', 'pm', 'pn', 'pr', 'ps', 'pt', 'pw', 'py', 'qa', 're', 'ro', 'ru', 'rw', 'sa', 'sb', 'sc', 'sd', 'se', 'sg', 'sh', 'si', 'sj', 'sk', 'sl', 'sm', 'sn', 'so', 'sr', 'st', 'sv', 'sy', 'sz', 'tc', 'td', 'tf', 'tg', 'th', 'tj', 'tk', 'tm', 'tn', 'to', 'tp', 'tr', 'tt', 'tv', 'tw', 'tz', 'ua', 'ug', 'uk', 'um', 'us', 'uy', 'uz', 'va', 'vc', 've', 'vg', 'vi', 'vn', 'vu', 'wf', 'ws', 'ye', 'yt', 'yu', 'za', 'zm', 'zw');
-        $gTLD = array('arpa', 'com', 'edu' , 'gov', 'int', 'mil', 'net', 'org');
-        $newTLD = array('aero', 'biz', 'coop', 'info', 'museum', 'name', 'pro', 'eu');
-        $TLD = array_merge($ccTLD, $gTLD);
-        $allTLD = array_merge($TLD, $newTLD);
-    }
-
     list($userName, $hostName) = explode('@', $email);
     if (!preg_match("/^[a-z0-9\_\-\.\%]+$/i", $userName)) return t('Diese Email ist ungültig (Falscher Benutzer-Teil)');
     if (!preg_match("/^([a-z0-9]+[\-\.]{0,1})+\.[a-z]+$/i", $hostName)) return t('Diese Email ist ungültig (Falscher Host-Teil)');
 
     $subdomains = explode('.', $hostName);
     $tld = $subdomains[count($subdomains) - 1];
-    if (!in_array($tld, $allTLD)) return t('Diese Email ist ungültig (Nicht existierende Domain)');
+    
+    $validTld = $db->qry_first("SELECT 1 AS found FROM %prefix%tlds WHERE tld = %string% %plain%", $table, $tld);
+    if (!$row['found']) return t('Diese Email ist ungültig (Nicht existierende Domain)');
 
     $TrashMailDomains = explode("\n", $cfg['mf_forbidden_trashmail_domains']);
     foreach ($TrashMailDomains as $key => $val) $TrashMailDomains[$key] = trim($val);

--- a/inc/classes/class_masterform.php
+++ b/inc/classes/class_masterform.php
@@ -703,12 +703,24 @@ global $cfg;
 
   if ($email == '') return t('Bitte gib deine Email ein');
   elseif (substr_count($email, '@') != 1) return t('Die Adresse muss genau ein @-Zeichen enthalten');
-  else {
-    $ccTLD = array('ac', 'ad', 'ae', 'af', 'ag', 'ai', 'al', 'am', 'an', 'ao', 'aq', 'ar', 'as', 'at', 'au', 'aw', 'az', 'ba', 'bb', 'bd', 'be', 'bf', 'bg', 'bh', 'bi', 'bj', 'bm', 'bn', 'bo', 'br', 'bs', 'bt', 'bv', 'bw', 'by', 'bz', 'ca', 'cc', 'cd', 'cf', 'cg', 'ch', 'ci', 'ck', 'cl', 'cm', 'cn', 'co', 'cr', 'cu', 'cv', 'cx', 'cy', 'cz', 'de', 'dj', 'dk', 'dm', 'do', 'dz', 'ec', 'ee', 'eg', 'eh', 'er', 'es', 'et', 'fi', 'fj', 'fk', 'fm', 'fo', 'fr', 'ga', 'gd', 'ge', 'gf', 'gg', 'gh', 'gi', 'gl', 'gm', 'gn', 'gp', 'gq', 'gr', 'gs', 'gt', 'gu', 'gw', 'gy', 'hk', 'hm', 'hn', 'hr', 'ht', 'hu', 'id', 'ie', 'il', 'im', 'in', 'io', 'iq', 'ir', 'is', 'it', 'je', 'jm', 'jo', 'jp', 'ke', 'kg', 'kh', 'ki', 'km', 'kn', 'kp', 'kr', 'kw', 'ky', 'kz', 'la', 'lb', 'lc', 'li', 'lk', 'lr', 'ls', 'lt', 'lu', 'lv', 'ly', 'ma', 'mc', 'md', 'mg', 'mh', 'mk', 'ml', 'mm', 'mn', 'mo', 'mp', 'mq', 'mr', 'ms', 'mt', 'mu', 'mv', 'mw', 'mx', 'my', 'mz', 'na', 'nc', 'ne', 'nf', 'ng', 'ni', 'nl', 'no', 'np', 'nr', 'nu', 'nz', 'om', 'pa', 'pe', 'pf', 'pg', 'ph', 'pk', 'pl', 'pm', 'pn', 'pr', 'ps', 'pt', 'pw', 'py', 'qa', 're', 'ro', 'ru', 'rw', 'sa', 'sb', 'sc', 'sd', 'se', 'sg', 'sh', 'si', 'sj', 'sk', 'sl', 'sm', 'sn', 'so', 'sr', 'st', 'sv', 'sy', 'sz', 'tc', 'td', 'tf', 'tg', 'th', 'tj', 'tk', 'tm', 'tn', 'to', 'tp', 'tr', 'tt', 'tv', 'tw', 'tz', 'ua', 'ug', 'uk', 'um', 'us', 'uy', 'uz', 'va', 'vc', 've', 'vg', 'vi', 'vn', 'vu', 'wf', 'ws', 'ye', 'yt', 'yu', 'za', 'zm', 'zw');
-    $gTLD = array('arpa', 'com', 'edu' , 'gov', 'int', 'mil', 'net', 'org');
-    $newTLD = array('aero', 'biz', 'coop', 'info', 'museum', 'name', 'pro', 'eu');
-    $TLD = array_merge($ccTLD, $gTLD);
-    $allTLD = array_merge($TLD, $newTLD);
+  else {	
+    $allTLD = array();
+    // can be loaded via  'wget -O tlds.txt http://data.iana.org/TLD/tlds-alpha-by-domain.txt'
+    // try to open tlds.txt in root folder which should contain all allowed tlds (http://data.iana.org/TLD/tlds-alpha-by-domain.txt)
+    if (file_exists ("tlds.txt")) {
+            $tldFile = fopen("tlds.txt","r");
+            while(!feof($tldFile)){
+                    $line = fgets($tldFile);
+                    $allTLD[] = strtolower(trim($line));
+            }
+            fclose($tldFile);
+    } else {
+        $ccTLD = array('ac', 'ad', 'ae', 'af', 'ag', 'ai', 'al', 'am', 'an', 'ao', 'aq', 'ar', 'as', 'at', 'au', 'aw', 'az', 'ba', 'bb', 'bd', 'be', 'bf', 'bg', 'bh', 'bi', 'bj', 'bm', 'bn', 'bo', 'br', 'bs', 'bt', 'bv', 'bw', 'by', 'bz', 'ca', 'cc', 'cd', 'cf', 'cg', 'ch', 'ci', 'ck', 'cl', 'cm', 'cn', 'co', 'cr', 'cu', 'cv', 'cx', 'cy', 'cz', 'de', 'dj', 'dk', 'dm', 'do', 'dz', 'ec', 'ee', 'eg', 'eh', 'er', 'es', 'et', 'fi', 'fj', 'fk', 'fm', 'fo', 'fr', 'ga', 'gd', 'ge', 'gf', 'gg', 'gh', 'gi', 'gl', 'gm', 'gn', 'gp', 'gq', 'gr', 'gs', 'gt', 'gu', 'gw', 'gy', 'hk', 'hm', 'hn', 'hr', 'ht', 'hu', 'id', 'ie', 'il', 'im', 'in', 'io', 'iq', 'ir', 'is', 'it', 'je', 'jm', 'jo', 'jp', 'ke', 'kg', 'kh', 'ki', 'km', 'kn', 'kp', 'kr', 'kw', 'ky', 'kz', 'la', 'lb', 'lc', 'li', 'lk', 'lr', 'ls', 'lt', 'lu', 'lv', 'ly', 'ma', 'mc', 'md', 'mg', 'mh', 'mk', 'ml', 'mm', 'mn', 'mo', 'mp', 'mq', 'mr', 'ms', 'mt', 'mu', 'mv', 'mw', 'mx', 'my', 'mz', 'na', 'nc', 'ne', 'nf', 'ng', 'ni', 'nl', 'no', 'np', 'nr', 'nu', 'nz', 'om', 'pa', 'pe', 'pf', 'pg', 'ph', 'pk', 'pl', 'pm', 'pn', 'pr', 'ps', 'pt', 'pw', 'py', 'qa', 're', 'ro', 'ru', 'rw', 'sa', 'sb', 'sc', 'sd', 'se', 'sg', 'sh', 'si', 'sj', 'sk', 'sl', 'sm', 'sn', 'so', 'sr', 'st', 'sv', 'sy', 'sz', 'tc', 'td', 'tf', 'tg', 'th', 'tj', 'tk', 'tm', 'tn', 'to', 'tp', 'tr', 'tt', 'tv', 'tw', 'tz', 'ua', 'ug', 'uk', 'um', 'us', 'uy', 'uz', 'va', 'vc', 've', 'vg', 'vi', 'vn', 'vu', 'wf', 'ws', 'ye', 'yt', 'yu', 'za', 'zm', 'zw');
+        $gTLD = array('arpa', 'com', 'edu' , 'gov', 'int', 'mil', 'net', 'org');
+        $newTLD = array('aero', 'biz', 'coop', 'info', 'museum', 'name', 'pro', 'eu');
+        $TLD = array_merge($ccTLD, $gTLD);
+        $allTLD = array_merge($TLD, $newTLD);
+    }
 
     list($userName, $hostName) = explode('@', $email);
     if (!preg_match("/^[a-z0-9\_\-\.\%]+$/i", $userName)) return t('Diese Email ist ungültig (Falscher Benutzer-Teil)');
@@ -716,7 +728,7 @@ global $cfg;
 
     $subdomains = explode('.', $hostName);
     $tld = $subdomains[count($subdomains) - 1];
-    if (!in_array($tld, $allTLD)) return t('Diese Email ist ungültig (Nicht exitsierende Domain)');
+    if (!in_array($tld, $allTLD)) return t('Diese Email ist ungültig (Nicht existierende Domain)');
 
     $TrashMailDomains = explode("\n", $cfg['mf_forbidden_trashmail_domains']);
     foreach ($TrashMailDomains as $key => $val) $TrashMailDomains[$key] = trim($val);

--- a/modules/cron2/add.php
+++ b/modules/cron2/add.php
@@ -5,8 +5,9 @@ include_once('inc/classes/class_masterform.php');
 $mf = new masterform();
 
 $mf->AddField(t('Name'), 'name');
-$mf->AddField(t('SQL-Statement'), 'function');
+$mf->AddField(t('Statement'), 'function');
 $mf->AddField(t('Aktiv'), 'active');
+$mf->AddField(t('Type'), 'type');
 $mf->AddField(t('Ausführen täglich, um'), 'runat');
 
 $mf->SendForm('index.php?mod=cron2&action=add', 'cron', 'jobid', $_GET['jobid'])

--- a/modules/cron2/class_cron2.php
+++ b/modules/cron2/class_cron2.php
@@ -6,9 +6,14 @@ class cron2{
 
     if (!$jobid) return false;
 
-    $row = $db->qry_first("SELECT name, function FROM %prefix%cron WHERE jobid = %int%", $jobid);
-    $db->qry('%plain%', $func->AllowHTML($row['function']));
-    $db->qry("UPDATE %prefix%cron SET lastrun = NOW() WHERE jobid = %int%", $jobid);
+    $row = $db->qry_first("SELECT name, type, function FROM %prefix%cron WHERE jobid = %int%", $jobid);
+    
+    if ($row['type'] == 'sql') {
+        $db->qry('%plain%', $func->AllowHTML($row['function']));
+        $db->qry("UPDATE %prefix%cron SET lastrun = NOW() WHERE jobid = %int%", $jobid);
+    } elseif ($row['type'] == "php") {
+        require_once 'ext_scripts/'.$row['function'];
+    }
 
     $func->log_event(t('Cronjob "%1" wurde ausgeführt', array($row['name'])), 1);
 

--- a/modules/cron2/mod_settings/db.xml
+++ b/modules/cron2/mod_settings/db.xml
@@ -35,7 +35,15 @@
 				<key></key>
 				<default></default>
 				<extra></extra>
-			</field>			
+			</field>	
+			<field>
+				<name>type</name>
+				<type>varchar(3)</type>
+				<null></null>
+				<key></key>
+				<default>sql</default>
+				<extra></extra>
+			</field>		
 			<field>
 				<name>active</name>
 				<type>tinyint(1)</type>

--- a/modules/usrmgr/mod_settings/db.xml
+++ b/modules/usrmgr/mod_settings/db.xml
@@ -531,4 +531,19 @@
             </field>
         </structure>
     </table>
+        <table>
+        <table_head>
+            <name>tlds</name>
+        </table_head>
+        <structure>
+            <field>
+                <name>tld</name>
+                <type>varchar(64)</type>
+                <null></null>
+                <default></default>
+                <extra></extra>
+                <key>PRI</key>
+            </field>
+        </structure>
+    </table>
 </lansuite>


### PR DESCRIPTION
Mit der den neuen Domain-Endungen ist die Array-Lösung aus Lansuite keine sinnvolle Idee mehr. Folgender Code liest eine Datei tlds.txt aus dem Root-Verzeichnis von Lansuite ein. 
Diese kann auf einen Linux mit wget mit folgendem Code geladen werden

wget -O tlds.txt http://data.iana.org/TLD/tlds-alpha-by-domain.txt

Wenn die Datei gefunden wird, wird bei der Mail-Validierung die Datei geparst. Ansonsten wird als Fallback weiterhin die Array-Variante unterstützt.
