### PR TITLE
Redesigned Lookup Code for GoogleMaps to handle Query-Limits

### DIFF
--- a/modules/guestlist/templates/googlemaps.htm
+++ b/modules/guestlist/templates/googlemaps.htm
@@ -1,6 +1,6 @@
 <div id="GoogleMaps" style="width:100%; height:600px"></div>
 <div id="mapcode">
-<script type="text/javascript" src="https://maps.google.com/maps/api/js?sensor=true">
+<script type="text/javascript" src="https://maps.google.com/maps/api/js">
 </script>
 <script type="text/javascript">
 {literal}
@@ -15,73 +15,55 @@ function ShowMap() {
 
   var geocoder = new google.maps.Geocoder();
   var infoWindow = null;
+  var nextAddress = 0;
+  var delay = 1000;
+  
+  function getAddress(address, next) {
+	if (address == null) return;  
+	if (address.country == '') return;
+	if (address.city == '' && plz == '') return;
+	  
+	searchAddress = address.country + ' ' + address.city;
+	
+	if (address.street) searchAddress = searchAddress + ' ' + address.street;
+	if (address.hnr) searchAddress = searchAddress + ' '  + address.hnr;
 
-  function showAddress(country, city, plz, street, hnr, text) {
-    if (country == '') country = 'Germany';
-    if (city == '' && plz == '') return;
-
-    geocoder.geocode( { 'address': street+' '+hnr+', '+plz+' '+city+', '+country }, function(results, status) {
-      if (status == google.maps.GeocoderStatus.OK) {
-        var marker = new google.maps.Marker({
-          map: map,
-          position: results[0].geometry.location
-        });
-        google.maps.event.addListener(marker, 'click', function() {
-          if (infoWindow) infoWindow.close();
-          infoWindow = new google.maps.InfoWindow({
-            content: text
-          });
-          infoWindow.open(map, marker);
-        });
-      } else geocoder.geocode( { 'address': street+', '+plz+' '+city+', '+country }, function(results, status) {
-        if (status == google.maps.GeocoderStatus.OK) {
-          var marker = new google.maps.Marker({
-            map: map,
-            position: results[0].geometry.location
-          });
-          google.maps.event.addListener(marker, 'click', function() {
-            if (infoWindow) infoWindow.close();
-            infoWindow = new google.maps.InfoWindow({
-              content: text
-            });
-            infoWindow.open(map, marker);
-          });
-        } else geocoder.geocode( { 'address': street+', '+plz+', '+country }, function(results, status) {
-          if (status == google.maps.GeocoderStatus.OK) {
-            var marker = new google.maps.Marker({
-              map: map,
-              position: results[0].geometry.location
-            });
-            google.maps.event.addListener(marker, 'click', function() {
-              if (infoWindow) infoWindow.close();
-              infoWindow = new google.maps.InfoWindow({
-                content: text
-              });
-              infoWindow.open(map, marker);
-            });
-          } else geocoder.geocode( { 'address': street+', '+city+', '+country }, function(results, status) {
-            if (status == google.maps.GeocoderStatus.OK) {
-              var marker = new google.maps.Marker({
-                map: map,
-                position: results[0].geometry.location
-              });
-              google.maps.event.addListener(marker, 'click', function() {
-                if (infoWindow) infoWindow.close();
-                infoWindow = new google.maps.InfoWindow({
-                  content: text
-                });
-                infoWindow.open(map, marker);
-              });
-            }
-          });
-        });
-      });
-    });
-  }
+    geocoder.geocode( { 'address': searchAddress }, 
+   		function(results, status) {
+		      if (status == google.maps.GeocoderStatus.OK) {
+		        var marker = new google.maps.Marker({
+		          map: map,
+		          position: results[0].geometry.location
+		        });
+		        
+		        google.maps.event.addListener(marker, 'click', function() {
+		          if (infoWindow) infoWindow.close();
+		          infoWindow = new google.maps.InfoWindow({
+		            content: address.text
+		          });
+		          infoWindow.open(map, marker);
+		        });
+		        if (delay > 250) delay = delay / 2;
+		      } else if (status == google.maps.GeocoderStatus.OVER_QUERY_LIMIT) {
+	               nextAddress--;
+	               if (delay < 2000) delay = delay * 2;	       
+		      }
+		      next();
+    	}		
+     );
+    }
+    
+    function getNext () {
+    	nextAddress++;
+    	if (nextAddress < adresses.length) setTimeout(()=>{getAddress(adresses[nextAddress], getNext)}, delay);
+    	return null;
+    }
+  
 
 {/literal}
   {$adresses}
 {literal}
+setTimeout(()=>{getAddress(adresses[nextAddress], getNext)}, delay); 
 }
 {/literal}
 </script>

--- a/modules/guestlist/usermap.php
+++ b/modules/guestlist/usermap.php
@@ -16,6 +16,7 @@ if ($cfg['guestlist_guestmap'] == 2) {
       ", $where_pid);
 
     $templ['addresses'] = '';
+    $adresses = 'var adresses = [';
     while ($row = $db->fetch_array($res)) {
 
       ($row['country'])? $country = $row['country'] : $country = $cfg['sys_country'];
@@ -37,8 +38,9 @@ if ($cfg['guestlist_guestmap'] == 2) {
 
       if ($func->chk_img_path($row['avatar_path'])) $text .= '<br>'. sprintf('<img src=\\"%s\\" alt=\\"%s\\" border=\\"0\\">', $row["avatar_path"], '');
 
-      $adresses .= "showAddress('$GCountry', '{$row['city']}', '{$row['plz']}', '{$row['street']}', '{$row['hnr']}', '$text');\r\n";
+      $adresses .= "{'country':'$GCountry', 'city':'{$row['city']}', 'plz':'{$row['plz']}', 'street':'{$row['street']}', 'hnr':'{$row['hnr']}', 'text':'$text'},\r\n";
     }
+    $adresses .= '];';
     $db->free_result($haus_data);
 
     $smarty->assign('adresses', $adresses);


### PR DESCRIPTION
Uns ist aufgefallen, dass nicht im Ansatz alle Gäste unserer LAN-Party auf der Besucherkarte angezeigt werden, obwohl der Schalter "Mich auf der Karte zeigen" aktiv ist.

Bei der Ursachenforschung hat sich herausgestellt, dass Google mittlerweile ein QueryLimit für Clients in der API hinterlegt hat.
Eine IP-Adresse (anonym ohne API-Key) kann etwa 10-15 Queries pro Sekunde absetzen.
Angehängter Code setzt beim Auftreten eines OVER_QUERY_LIMIT ein Delay für weitere Queries, sodass nach und nach alle Ergebnisse eintrudeln. 

Code ist mehr oder weniger von hier http://stackoverflow.com/questions/11792916/over-query-limit-in-google-maps-api-v3-how-do-i-pause-delay-in-javascript-to-sl
